### PR TITLE
Changed subshapes mopp generation

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,6 +1,10 @@
-            NifMopp 1.0.0.1
+            NifMopp 1.0.0.2
             =================
-
+	
+	Changed multi-material shape calculation. 
+			
+            NifMopp 1.0.0.1
+			
     This file is a helper library for accessing Havok libraries for generating 
     MOPP code from meshes.
     


### PR DESCRIPTION
Mopp code from FO3 shows that every shape has a material id linked with a 0B 0X goto instructioninside the moppcode. 
Such instruction is generated by the MOPP compiler whenever the key number the shape key is higher than 0x00FFFFFF. 

A simple hkSimpleShape derived class with the get methods overriden to follow this convention seems  to generate a bytecodeworking ingame for custom shapes